### PR TITLE
Feat: Add RISC-style LUI, JAL, JR instructions

### DIFF
--- a/MCU-ISA.md
+++ b/MCU-ISA.md
@@ -1,126 +1,193 @@
-Registers:
-There are 8 general-purpose 16-bit registers, referred to as R0 through R7.
-- R0 (A): General purpose register A
-- R1 (B): General purpose register B
-- R2 (C): General purpose register C
-- R3 (D): General purpose register D
-- R4 (PC): Program Counter, 16-bit
-- R5 (SP): Stack Pointer, 16-bit
-- R6 (FLG): Flag Register, 16-bit (lower 8 bits used: {C,Z,S,O,0,0,0,0}, C is bit 0)
-- R7 (CTL): Control Register / Link Register. Used by JAL to store the return address (PC+1).
+# ISA Overview
 
-When a 4-bit field in an instruction (X, Y, or Z) refers to a register:
-- If the field's MSB (e.g., X[3]) is 0, the lower 3 bits (e.g., X[2:0]) select one of R0-R7.
-- If the field's MSB is 1, this often indicates an immediate value. See specific instruction descriptions.
+This document describes a 16-bit microcontroller ISA (Instruction Set Architecture). Key features include:
 
-Instruction Format:
-General format: AAAA XXXX YYYY ZZZZ (16-bit instructions)
-- AAAA: Opcode
-- XXXX: X field (source operand, address, or mode)
-- YYYY: Y field (source operand, address, or mode)
-- ZZZZ: Z field (destination operand, address, or mode)
+*   **16-bit Instructions:** All instructions are 16 bits wide.
+*   **16 General-Purpose Registers:** It uses 16 general-purpose registers (R0-R15), with specific roles assigned to R12-R15 (FLG, LR, SP, PC).
+*   **OpFamily Field:** The primary instruction category and format are determined by the top 4 bits of the instruction, `ir[15:12]` (OpFamily).
+*   **2-Operand Destructive ALU:** All Arithmetic Logic Unit (ALU) operations are 2-operand and destructive, meaning the result of an operation overwrites one of the source registers.
 
-Opcodes (AAAA):
+## Registers
 
-ALU Operations:
-For all ALU operations (ADD, SUB, MUL, SHL, AND, OR, XOR, SHR), the result is stored in Rz (where z = ZZZZ[2:0]).
-X and Y can be registers or 3-bit immediate values. If the MSB of the X (or Y) field in the instruction is 1, the lower 3 bits of that field (X[2:0] or Y[2:0]) are used as an immediate value, zero-extended to 16 bits. Otherwise, the register specified by X[2:0] (or Y[2:0]) is used. Flags in FLG may be affected.
+There are 16 general-purpose 16-bit registers, R0 through R15.
 
-0000 ADD Rx, Ry -> Rz  (or ADD immX, Ry -> Rz, ADD Rx, immY -> Rz, ADD immX, immY -> Rz)
-     Action: Rz <= Rx + Ry.
-     X and Y can be registers or 3-bit immediate values. If the MSB of the X (or Y) field in the instruction is 1, the lower 3 bits of that field (X[2:0] or Y[2:0]) are used as an immediate value, zero-extended to 16 bits. Otherwise, the register specified by X[2:0] (or Y[2:0]) is used.
-0001 SUB Rx, Ry -> Rz (or SUB immX, Ry -> Rz, etc.)
-     Action: Rz <= Rx - Ry.
-     X and Y can be registers or 3-bit immediate values. If the MSB of the X (or Y) field in the instruction is 1, the lower 3 bits of that field (X[2:0] or Y[2:0]) are used as an immediate value, zero-extended to 16 bits. Otherwise, the register specified by X[2:0] (or Y[2:0]) is used.
-0010 MUL Rx, Ry -> Rz (or MUL immX, Ry -> Rz, etc.)
-     Action: Rz <= Rx * Ry.
-     X and Y can be registers or 3-bit immediate values. If the MSB of the X (or Y) field in the instruction is 1, the lower 3 bits of that field (X[2:0] or Y[2:0]) are used as an immediate value, zero-extended to 16 bits. Otherwise, the register specified by X[2:0] (or Y[2:0]) is used.
-0011 SHL Rx, Ry -> Rz (or SHL immX, Ry -> Rz, etc.)
-     Action: Rz <= Rx << Ry (logical shift left). Ry specifies shift amount (0-15).
-     X and Y can be registers or 3-bit immediate values. If the MSB of the X (or Y) field in the instruction is 1, the lower 3 bits of that field (X[2:0] or Y[2:0]) are used as an immediate value, zero-extended to 16 bits. Otherwise, the register specified by X[2:0] (or Y[2:0]) is used.
-0100 AND Rx, Ry -> Rz (or AND immX, Ry -> Rz, etc.)
-     Action: Rz <= Rx & Ry.
-     X and Y can be registers or 3-bit immediate values. If the MSB of the X (or Y) field in the instruction is 1, the lower 3 bits of that field (X[2:0] or Y[2:0]) are used as an immediate value, zero-extended to 16 bits. Otherwise, the register specified by X[2:0] (or Y[2:0]) is used.
-0101 OR Rx, Ry -> Rz (or OR immX, Ry -> Rz, etc.)
-     Action: Rz <= Rx | Ry.
-     X and Y can be registers or 3-bit immediate values. If the MSB of the X (or Y) field in the instruction is 1, the lower 3 bits of that field (X[2:0] or Y[2:0]) are used as an immediate value, zero-extended to 16 bits. Otherwise, the register specified by X[2:0] (or Y[2:0]) is used.
-0110 XOR Rx, Ry -> Rz (or XOR immX, Ry -> Rz, etc.)
-     Action: Rz <= Rx ^ Ry.
-     X and Y can be registers or 3-bit immediate values. If the MSB of the X (or Y) field in the instruction is 1, the lower 3 bits of that field (X[2:0] or Y[2:0]) are used as an immediate value, zero-extended to 16 bits. Otherwise, the register specified by X[2:0] (or Y[2:0]) is used.
-0111 SHR Rx, Ry -> Rz (or SHR immX, Ry -> Rz, etc.)
-     Action: Rz <= Rx >> Ry (logical shift right). Ry specifies shift amount (0-15).
-     X and Y can be registers or 3-bit immediate values. If the MSB of the X (or Y) field in the instruction is 1, the lower 3 bits of that field (X[2:0] or Y[2:0]) are used as an immediate value, zero-extended to 16 bits. Otherwise, the register specified by X[2:0] (or Y[2:0]) is used.
+*   **R0-R11:** General-purpose registers.
+*   **R12 (FLG):** Flag Register. Stores CPU flags like Carry (C), Zero (Z), Sign (S), Overflow (O). The lower 8 bits are typically used: `{C,Z,S,O,0,0,0,0}` where C is bit 0. This register is updated implicitly by ALU operations.
+*   **R13 (LR):** Link Register. Used by the JAL (Jump and Link) instruction to store the return address (PC+1).
+*   **R14 (SP):** Stack Pointer. Used to manage the runtime stack. Its usage (e.g., growing direction) is by convention.
+*   **R15 (PC):** Program Counter. Always holds the address of the next instruction to be fetched and executed.
 
-Control Flow Instructions:
+## Instruction Set Architecture
 
-1000 JMP cond, value
-     Instruction: 1000 ZZZZ YYYY XXXX
-     Action: If (FLG[3:0] & XXXX[3:0]) == YYYY[3:0], then PC <= Rz (or PC <= immZ if ZZZZ[3]=1).
-     Rz is specified by ZZZZ[2:0]. If ZZZZ[3] is 1, ZZZZ[2:0] is an immediate value (zero-extended).
-     XXXX is a 4-bit mask. YYYY is the 4-bit expected value after masking.
+All instructions are 16-bit wide. The `OpFam[3:0]` field (`ir[15:12]`) is the primary opcode that determines the instruction category and format.
 
-Load/Store and Move Instructions:
+### Category 1: ALU Register-Register Operations (OpFamily `0000`, `0001`)
 
-1001 LOAD imm8 (LOADl/LOADh)
-     Instruction: 1001 ZZZZ YYYY XXXX
-     This instruction loads an 8-bit immediate value into either the lower or upper byte of register Rz (where z = ZZZZ[2:0]).
-     The 8-bit immediate is formed by concatenating the YYYY and XXXX fields: imm8 = {YYYY, XXXX}.
-     - If ZZZZ[3] is 0 (LOADl): Rz[7:0] <= imm8. Rz[15:8] remains unchanged.
-     - If ZZZZ[3] is 1 (LOADh): Rz[15:8] <= imm8. Rz[7:0] remains unchanged.
-     Note: ZZZZ[2:0] must specify a valid register index (0-7). FLG (R6) and CTL (R7) cannot be destinations for this instruction.
+Instructions in this category perform arithmetic and logical operations between two registers, where the result overwrites the first source register (Rx_dst_s1).
 
-1010 MOVE Operations:
-     Instruction format: 1010 ZZZZ YYYY XXXX
-     Ry is specified by YYYY[2:0] (YYYY[3] must be 0).
-     Rz is specified by ZZZZ[2:0] (ZZZZ[3] must be 0).
+**Format:** `OpFam[15:12] OpSpecific[11:8] Rx_dst_s1[7:4] Ry_s2[3:0]`
 
-     Sub-opcodes via XXXX field:
-     - XXXX = 0000: MOVE Ry, Rz
-       Action: Rz <= Ry.
-     - XXXX = 0001: MOVE [Ry], Rz (Load from memory)
-       Action: Rz <= MEM[Ry].
-     - XXXX = 0010: MOVE Ry, [Rz] (Store to memory)
-       Action: MEM[Rz] <= Ry.
-     - XXXX = 0011: MOVE [Ry], [Rz] (Memory to memory)
-       Action: MEM[Rz] <= MEM[Ry]. (This would typically require a temporary internal register or multiple cycles not explicitly shown here).
+*   `OpFam[15:12]`: Defines the instruction category (e.g., `0000` for primary R-R ALU).
+*   `OpSpecific[11:8]`: Specifies the particular ALU operation (e.g., ADD, SUB).
+*   `Rx_dst_s1[7:4]`: Specifies the destination register which also serves as the first source operand (R0-R14).
+*   `Ry_s2[3:0]`: Specifies the second source operand register (R0-R14).
 
-     - XXXX = 0110: PUSH Ry, [Rz] (PUSH Ry onto stack pointed by Rz)
-       Instruction: 1010 ZZZZ YYYY 0110
-       Action: MEM[Rz] <= Ry, then Rz <= Rz + 1.
-       (Ry is specified by YYYY[2:0], Rz by ZZZZ[2:0]. YYYY[3] and ZZZZ[3] should be 0 to select registers).
-       Commonly, Rz would be SP (R5).
+**OpFamily `0000`:**
 
-     - XXXX = 1001: POP [Ry], Rz (POP from stack pointed by Ry to Rz)
-       Instruction: 1010 ZZZZ YYYY 1001
-       Action: Rz <= MEM[Ry], then Ry <= Ry - 1.
-       (Ry is specified by YYYY[2:0], Rz by ZZZZ[2:0]. YYYY[3] and ZZZZ[3] should be 0 to select registers).
-       Commonly, Ry would be SP (R5).
+*   **`0000 0001 Rx Ry`**: `ADD Rx, Ry`
+    *   Action: `Rx <= Rx + Ry`
+    *   Updates FLG (R12).
+*   **`0000 0010 Rx Ry`**: `SUB Rx, Ry`
+    *   Action: `Rx <= Rx - Ry`
+    *   Updates FLG (R12).
+*   **`0000 0011 Rx Ry`**: `AND Rx, Ry`
+    *   Action: `Rx <= Rx & Ry`
+    *   Updates FLG (R12).
+*   **`0000 0100 Rx Ry`**: `OR  Rx, Ry`
+    *   Action: `Rx <= Rx | Ry`
+    *   Updates FLG (R12).
+*   **`0000 0101 Rx Ry`**: `XOR Rx, Ry`
+    *   Action: `Rx <= Rx ^ Ry`
+    *   Updates FLG (R12).
+*   **`0000 0110 Rx Ry`**: `SHL Rx, Ry` (Logical Shift Left)
+    *   Action: `Rx <= Rx << Ry[3:0]` (Shift amount from lower 4 bits of Ry)
+    *   Updates FLG (R12).
+*   **`0000 0111 Rx Ry`**: `SHR Rx, Ry` (Logical Shift Right)
+    *   Action: `Rx <= Rx >> Ry[3:0]` (Shift amount from lower 4 bits of Ry)
+    *   Updates FLG (R12).
+*   **`0000 1000 Rx Ry`**: `MUL Rx, Ry`
+    *   Action: `Rx <= Rx * Ry`
+    *   Updates FLG (R12).
 
-RISC-style Instructions:
+**OpFamily `0001`:** Reserved for additional Register-Register ALU operations (e.g., signed shifts, division, modulo).
 
-1100 LUI Rz, imm8 (Load Upper Immediate)
-     Instruction: 1100 ZZZZ YYYY XXXX
-     Action: Rz[15:8] <= {YYYY,XXXX}; Rz[7:0] <= 8'b00000000.
-     Description: Loads the 8-bit immediate value, formed by concatenating YYYY and XXXX fields (imm8 = {YYYY, XXXX}),
-     into the upper 8 bits of register Rz (specified by ZZZZ[2:0]). The lower 8 bits of Rz are set to zero.
-     ZZZZ[3] must be 0 (selecting R0-R7 as potential targets).
-     Note: The actual hardware implementation restricts Rz to R0-R6; Rz cannot be CTL (R7).
+### Category 2: ALU Register-Immediate Operations (OpFamily `0010` - `0101`)
 
-1101 JAL imm8_offset (Jump and Link)
-     Instruction: 1101 ---- YYYY XXXX 
-     Action: R7 <= PC + 1; PC <= PC + sign_extend({YYYY,XXXX}).
-     Description: Stores the address of the next instruction (PC+1) into the Link Register (R7/CTL).
-     Then, jumps to a new address calculated by adding the sign-extended 8-bit immediate offset (imm8_offset = {YYYY, XXXX})
-     to the current PC. The ZZZZ field is not used for register selection.
-     Note: imm8_offset is an 8-bit value. sign_extend means if imm8_offset[7] (MSB of the 8-bit immediate)
-     is 1, it's extended as a negative number (2's complement) for the 16-bit addition to PC.
+Instructions in this category perform arithmetic and logical operations between a register and an 8-bit immediate value. The result overwrites the source register (Rx_dst_s1).
 
-1110 JR Rx (Jump Register)
-     Instruction: 1110 ---- ---- XXXX
-     Action: PC <= Rx.
-     Description: Jumps to the address contained in register Rx (specified by XXXX[2:0]).
-     XXXX[3] must be 0. The YYYY and ZZZZ fields are not used.
+**Format:** `OpFam[15:12] Rx_dst_s1[11:8] Imm[7:0]`
 
-Memory Mapping:
+*   `OpFam[15:12]`: Defines the ALU operation type (e.g., `0010` for ADDI).
+*   `Rx_dst_s1[11:8]`: Specifies the destination register which also serves as the source operand (R0-R14).
+*   `Imm[7:0]`: Specifies the 8-bit immediate value (`ir[7:0]`).
+
+**Instructions:**
+
+*   **`0010 Rx Imm8`**: `ADDI Rx, imm8` (Add Immediate)
+    *   Action: `Rx <= Rx + sign_extend(imm8)`
+    *   Updates FLG (R12).
+*   **`0011 Rx Imm8`**: `ANDI Rx, imm8` (AND Immediate)
+    *   Action: `Rx <= Rx & zero_extend(imm8)`
+    *   Updates FLG (R12).
+*   **`0100 Rx Imm8`**: `ORI  Rx, imm8` (OR Immediate)
+    *   Action: `Rx <= Rx | zero_extend(imm8)`
+    *   Updates FLG (R12).
+*   **`0101 Rx Imm8`**: `XORI Rx, imm8` (XOR Immediate)
+    *   Action: `Rx <= Rx ^ zero_extend(imm8)`
+    *   Updates FLG (R12).
+
+*(OpFamilies `0110`, `0111` are reserved for additional Register-Immediate ALU operations).*
+
+### Category 3: Load/Store Operations (OpFamily `1000`, `1001`)
+
+These instructions are used to transfer data between registers and memory.
+
+**LOAD Operation:**
+
+*   **`1000 Rt[11:8] Rs_addr[7:4] Imm[3:0]`**: `LOAD Rt, imm4_offset(Rs_addr)` (Load Word)
+    *   Action: `Rt <= MEM[Rs_addr + zero_extend(imm4)]`. The immediate is a 4-bit unsigned byte offset.
+    *   `Rt` (destination, R0-R14) is specified by `ir[11:8]`.
+    *   `Rs_addr` (base address register, R0-R14) is specified by `ir[7:4]`.
+    *   `Imm[3:0]` (4-bit unsigned offset) is `ir[3:0]`.
+
+**STORE Operation:**
+
+*   **`1001 Rt_data[11:8] Rs_addr[7:4] Imm[3:0]`**: `STORE Rt_data, imm4_offset(Rs_addr)` (Store Word)
+    *   Action: `MEM[Rs_addr + zero_extend(imm4)] <= Rt_data`. The immediate is a 4-bit unsigned byte offset.
+    *   `Rt_data` (source data register, R0-R14) is specified by `ir[11:8]`.
+    *   `Rs_addr` (base address register, R0-R14) is specified by `ir[7:4]`.
+    *   `Imm[3:0]` (4-bit unsigned offset) is `ir[3:0]`.
+
+*Note: PUSH/POP operations can be synthesized using LOAD/STORE with the Stack Pointer (SP, R14) and appropriate immediate offsets. For example:*
+*   *PUSH Rx: `ADDI SP, SP, -2` (if word addressing, or -N for N bytes), then `STORE Rx, 0(SP)`.*
+*   *POP Rx: `LOAD Rx, 0(SP)`, then `ADDI SP, SP, 2` (if word addressing, or +N for N bytes).*
+
+### 3.4. Category 4: LUI & Control Flow (OpFamily `1100` - `1111`)
+
+This category includes Load Upper Immediate and various control flow instructions.
+
+-   **`LUI Rt, imm8` (Load Upper Immediate)**
+    -   OpFamily: `1100`
+    -   Format: `1100 Rt[3:0] Imm[7:0]`
+        -   `Rt[3:0]` (destination register) is `ir[11:8]`.
+        -   `Imm[7:0]` (8-bit immediate) is `ir[7:0]`.
+    -   Action: `Rt[15:8] <= Imm[7:0]`, `Rt[7:0] <= 8'b00000000`.
+    -   Constraints: `Rt` can be R0-R14.
+
+-   **`JAL imm12_offset` (Jump and Link)**
+    -   OpFamily: `1101`
+    -   Format: `1101 Offset[11:0]`
+        -   `Offset[11:0]` (12-bit signed offset) is `ir[11:0]`.
+    -   Action: `R13 (LR) <= PC + 1` (address of the instruction after JAL), then `PC <= PC + sign_extend(Offset[11:0])`.
+    -   Description: Used for subroutine calls. Stores the return address in LR and jumps to a PC-relative target address.
+
+-   **`JR Rs_addr` (Jump Register)**
+    -   OpFamily: `1110`
+    -   Format: `1110 Rs_addr[3:0] --------` (Lower 8 bits `ir[7:0]` are unused)
+        -   `Rs_addr[3:0]` (register containing target address) is `ir[11:8]`.
+    -   Action: `PC <= Rs_addr`.
+    -   Constraints: `Rs_addr` can be R0-R14.
+
+-   **`JCOND cond4, imm8_offset` (Conditional Jump)**
+    -   OpFamily: `1111`
+    -   Format: `1111 Cond[3:0] Imm[7:0]`
+        -   `Cond[3:0]` (condition code) is `ir[11:8]`.
+        -   `Imm[7:0]` (8-bit signed offset) is `ir[7:0]`.
+    -   Action: `if (condition_met(Cond[3:0], FLG)) PC <= PC + sign_extend(Imm[7:0])`.
+
+    -   **Condition Codes (`Cond[3:0]` field from `ir[11:8]`):**
+        | `Cond` | Mnemonic | Condition for Jump     | FLG Bit Checked (Example) |
+        | :----- | :------- | :--------------------- | :------------------------ |
+        | `0000` | `JZ`     | Jump if Zero (Z=1)     | FLG[1] = 1                |
+        | `0001` | `JNZ`    | Jump if Not Zero (Z=0) | FLG[1] = 0                |
+        | `0010` | `JC`     | Jump if Carry (C=1)    | FLG[0] = 1                |
+        | `0011` | `JNC`    | Jump if No Carry (C=0) | FLG[0] = 0                |
+        | `0100` | `JS`     | Jump if Sign (S=1)     | FLG[2] = 1 (Negative)     |
+        | `0101` | `JNS`    | Jump if No Sign (S=0)  | FLG[2] = 0 (Non-negative) |
+        | `0110` | `JO`     | Jump if Overflow (O=1) | FLG[3] = 1                |
+        | `0111` | `JNO`    | Jump if No Overflow (O=0)| FLG[3] = 0                |
+        | `1000` | `JMPA`   | Jump Always            | Always true               |
+        | `1001`-`1111` |          | Reserved               | N/A                       |
+
+## 4. Opcode Summary
+
+| OpFamily (`ir[15:12]`) | Sub-Op (`ir[11:8]`) | Mnemonic        | Brief Description                                  | Instruction Format Fields                      |
+|------------------------|--------------------|-----------------|----------------------------------------------------|------------------------------------------------|
+| `0000`                 | `0001`             | `ADD Rx, Ry`    | `Rx <= Rx + Ry`                                    | `OpFam, OpSpec, Rx_dst_s1, Ry_s2`              |
+| `0000`                 | `0010`             | `SUB Rx, Ry`    | `Rx <= Rx - Ry`                                    | `OpFam, OpSpec, Rx_dst_s1, Ry_s2`              |
+| `0000`                 | `0011`             | `AND Rx, Ry`    | `Rx <= Rx & Ry`                                    | `OpFam, OpSpec, Rx_dst_s1, Ry_s2`              |
+| `0000`                 | `0100`             | `OR  Rx, Ry`    | `Rx <= Rx | Ry`                                    | `OpFam, OpSpec, Rx_dst_s1, Ry_s2`              |
+| `0000`                 | `0101`             | `XOR Rx, Ry`    | `Rx <= Rx ^ Ry`                                    | `OpFam, OpSpec, Rx_dst_s1, Ry_s2`              |
+| `0000`                 | `0110`             | `SHL Rx, Ry`    | `Rx <= Rx << Ry[3:0]`                              | `OpFam, OpSpec, Rx_dst_s1, Ry_s2`              |
+| `0000`                 | `0111`             | `SHR Rx, Ry`    | `Rx <= Rx >> Ry[3:0]` (Logical)                    | `OpFam, OpSpec, Rx_dst_s1, Ry_s2`              |
+| `0000`                 | `1000`             | `MUL Rx, Ry`    | `Rx <= Rx * Ry`                                    | `OpFam, OpSpec, Rx_dst_s1, Ry_s2`              |
+| `0001`                 | *Reserved*         |                 | More R-R ALU ops                                   |                                                |
+| `0010`                 | `----`             | `ADDI Rx, imm8` | `Rx <= Rx + sign_extend(imm8)`                     | `OpFam, Rx_dst_s1, Imm8`                       |
+| `0011`                 | `----`             | `ANDI Rx, imm8` | `Rx <= Rx & zero_extend(imm8)`                     | `OpFam, Rx_dst_s1, Imm8`                       |
+| `0100`                 | `----`             | `ORI  Rx, imm8` | `Rx <= Rx | zero_extend(imm8)`                     | `OpFam, Rx_dst_s1, Imm8`                       |
+| `0101`                 | `----`             | `XORI Rx, imm8` | `Rx <= Rx ^ zero_extend(imm8)`                     | `OpFam, Rx_dst_s1, Imm8`                       |
+| `0110`-`0111`          | *Reserved*         |                 | More R-I ALU ops                                   |                                                |
+| `1000`                 | `----`             | `LOAD Rt, imm4(Rs)`| `Rt <= MEM[Rs + imm4]`                          | `OpFam, Rt, Rs, Imm4`                          |
+| `1001`                 | `----`             | `STORE Rt, imm4(Rs)`| `MEM[Rs + imm4] <= Rt`                          | `OpFam, Rt, Rs, Imm4`                          |
+| `1100`                 | `----`             | `LUI Rt, imm8`  | `Rt[15:8] <= imm8, Rt[7:0] <= 0`                   | `OpFam, Rt, Imm8`                              |
+| `1101`                 | `----`             | `JAL offset12`  | `R13<=PC+1; PC<=PC+offset12`                       | `OpFam, Offset12 (ir[11:0])`                   |
+| `1110`                 | `----`             | `JR Rs`         | `PC <= Rs`                                         | `OpFam, Rs_addr (ir[11:8]), Unused (ir[7:0])`    |
+| `1111`                 | `Cond[3:0]`        | `JCOND cond, imm8`| `if (cond) PC <= PC + imm8`                      | `OpFam, Cond (ir[11:8]), Imm8 (ir[7:0])`       |
+
+## 5. Memory Mapping
+(This section can be retained if relevant, or updated as needed. Assuming it's still valid for now.)
+
 0000-07ff mcu_ram
 8000-83ff vram
+
+<!-- Trivial change for new branch creation -->

--- a/MCU-ISA.md
+++ b/MCU-ISA.md
@@ -1,33 +1,125 @@
-Register:
-ABCD rw  0000-1011
-PC   rw  0100
-SP   rw  0101
-CTL  rw  0110 
-FLG  ro  0111 {C,Z,S,O,0,0,0,0}
-IMMx ro  1xxx
+Registers:
+There are 8 general-purpose 16-bit registers, referred to as R0 through R7.
+- R0 (A): General purpose register A
+- R1 (B): General purpose register B
+- R2 (C): General purpose register C
+- R3 (D): General purpose register D
+- R4 (PC): Program Counter, 16-bit
+- R5 (SP): Stack Pointer, 16-bit
+- R6 (FLG): Flag Register, 16-bit (lower 8 bits used: {C,Z,S,O,0,0,0,0}, C is bit 0)
+- R7 (CTL): Control Register / Link Register. Used by JAL to store the return address (PC+1).
 
-Inst:
-1234567890ABCDEF
-AAAAXXXXYYYYZZZZ
+When a 4-bit field in an instruction (X, Y, or Z) refers to a register:
+- If the field's MSB (e.g., X[3]) is 0, the lower 3 bits (e.g., X[2:0]) select one of R0-R7.
+- If the field's MSB is 1, this often indicates an immediate value. See specific instruction descriptions.
 
-AAAA:
-0000 ADD X+Y->Z
-0001 SUB X-Y->Z
-0010 MUL X*Y->Z
-0011 SHL X<<Y->Z
-0100 AND X&Y->Z 
-0101 OR  X|Y->Z 
-0110 XOR X^Y->Z 
-0111 SHR X>>Y->Z
-1000 JMP Z -> PC if FLG[3:0] & X == Y
-1001 LOADl {XY} -> Z[7:0]  if Z[3]=0
-1001 LOADh {XY} -> Z[15:8] if Z[3]=1
-1010 MOVE {Y} -> {Z} (X=0000) //reg to reg
-1010 MOVE [Y] -> {Z} (X=0001) //mem to reg
-1010 MOVE {Y} -> [Z] (X=0010) //reg to mem
-1010 MOVE [Y] -> [Z] (X=0011) //mem to mem
-1010 PUSH {Y} -> [Z] (X=0110) //reg to mem, Z++
-1010 POP  [Y] -> {Z} (X=1001) //mem to reg, Y--
+Instruction Format:
+General format: AAAA XXXX YYYY ZZZZ (16-bit instructions)
+- AAAA: Opcode
+- XXXX: X field (source operand, address, or mode)
+- YYYY: Y field (source operand, address, or mode)
+- ZZZZ: Z field (destination operand, address, or mode)
+
+Opcodes (AAAA):
+
+ALU Operations:
+For all ALU operations (ADD, SUB, MUL, SHL, AND, OR, XOR, SHR), the result is stored in Rz (where z = ZZZZ[2:0]).
+X and Y can be registers or 3-bit immediate values. If the MSB of the X (or Y) field in the instruction is 1, the lower 3 bits of that field (X[2:0] or Y[2:0]) are used as an immediate value, zero-extended to 16 bits. Otherwise, the register specified by X[2:0] (or Y[2:0]) is used. Flags in FLG may be affected.
+
+0000 ADD Rx, Ry -> Rz  (or ADD immX, Ry -> Rz, ADD Rx, immY -> Rz, ADD immX, immY -> Rz)
+     Action: Rz <= Rx + Ry.
+     X and Y can be registers or 3-bit immediate values. If the MSB of the X (or Y) field in the instruction is 1, the lower 3 bits of that field (X[2:0] or Y[2:0]) are used as an immediate value, zero-extended to 16 bits. Otherwise, the register specified by X[2:0] (or Y[2:0]) is used.
+0001 SUB Rx, Ry -> Rz (or SUB immX, Ry -> Rz, etc.)
+     Action: Rz <= Rx - Ry.
+     X and Y can be registers or 3-bit immediate values. If the MSB of the X (or Y) field in the instruction is 1, the lower 3 bits of that field (X[2:0] or Y[2:0]) are used as an immediate value, zero-extended to 16 bits. Otherwise, the register specified by X[2:0] (or Y[2:0]) is used.
+0010 MUL Rx, Ry -> Rz (or MUL immX, Ry -> Rz, etc.)
+     Action: Rz <= Rx * Ry.
+     X and Y can be registers or 3-bit immediate values. If the MSB of the X (or Y) field in the instruction is 1, the lower 3 bits of that field (X[2:0] or Y[2:0]) are used as an immediate value, zero-extended to 16 bits. Otherwise, the register specified by X[2:0] (or Y[2:0]) is used.
+0011 SHL Rx, Ry -> Rz (or SHL immX, Ry -> Rz, etc.)
+     Action: Rz <= Rx << Ry (logical shift left). Ry specifies shift amount (0-15).
+     X and Y can be registers or 3-bit immediate values. If the MSB of the X (or Y) field in the instruction is 1, the lower 3 bits of that field (X[2:0] or Y[2:0]) are used as an immediate value, zero-extended to 16 bits. Otherwise, the register specified by X[2:0] (or Y[2:0]) is used.
+0100 AND Rx, Ry -> Rz (or AND immX, Ry -> Rz, etc.)
+     Action: Rz <= Rx & Ry.
+     X and Y can be registers or 3-bit immediate values. If the MSB of the X (or Y) field in the instruction is 1, the lower 3 bits of that field (X[2:0] or Y[2:0]) are used as an immediate value, zero-extended to 16 bits. Otherwise, the register specified by X[2:0] (or Y[2:0]) is used.
+0101 OR Rx, Ry -> Rz (or OR immX, Ry -> Rz, etc.)
+     Action: Rz <= Rx | Ry.
+     X and Y can be registers or 3-bit immediate values. If the MSB of the X (or Y) field in the instruction is 1, the lower 3 bits of that field (X[2:0] or Y[2:0]) are used as an immediate value, zero-extended to 16 bits. Otherwise, the register specified by X[2:0] (or Y[2:0]) is used.
+0110 XOR Rx, Ry -> Rz (or XOR immX, Ry -> Rz, etc.)
+     Action: Rz <= Rx ^ Ry.
+     X and Y can be registers or 3-bit immediate values. If the MSB of the X (or Y) field in the instruction is 1, the lower 3 bits of that field (X[2:0] or Y[2:0]) are used as an immediate value, zero-extended to 16 bits. Otherwise, the register specified by X[2:0] (or Y[2:0]) is used.
+0111 SHR Rx, Ry -> Rz (or SHR immX, Ry -> Rz, etc.)
+     Action: Rz <= Rx >> Ry (logical shift right). Ry specifies shift amount (0-15).
+     X and Y can be registers or 3-bit immediate values. If the MSB of the X (or Y) field in the instruction is 1, the lower 3 bits of that field (X[2:0] or Y[2:0]) are used as an immediate value, zero-extended to 16 bits. Otherwise, the register specified by X[2:0] (or Y[2:0]) is used.
+
+Control Flow Instructions:
+
+1000 JMP cond, value
+     Instruction: 1000 ZZZZ YYYY XXXX
+     Action: If (FLG[3:0] & XXXX[3:0]) == YYYY[3:0], then PC <= Rz (or PC <= immZ if ZZZZ[3]=1).
+     Rz is specified by ZZZZ[2:0]. If ZZZZ[3] is 1, ZZZZ[2:0] is an immediate value (zero-extended).
+     XXXX is a 4-bit mask. YYYY is the 4-bit expected value after masking.
+
+Load/Store and Move Instructions:
+
+1001 LOAD imm8 (LOADl/LOADh)
+     Instruction: 1001 ZZZZ YYYY XXXX
+     This instruction loads an 8-bit immediate value into either the lower or upper byte of register Rz (where z = ZZZZ[2:0]).
+     The 8-bit immediate is formed by concatenating the YYYY and XXXX fields: imm8 = {YYYY, XXXX}.
+     - If ZZZZ[3] is 0 (LOADl): Rz[7:0] <= imm8. Rz[15:8] remains unchanged.
+     - If ZZZZ[3] is 1 (LOADh): Rz[15:8] <= imm8. Rz[7:0] remains unchanged.
+     Note: ZZZZ[2:0] must specify a valid register index (0-7). FLG (R6) and CTL (R7) cannot be destinations for this instruction.
+
+1010 MOVE Operations:
+     Instruction format: 1010 ZZZZ YYYY XXXX
+     Ry is specified by YYYY[2:0] (YYYY[3] must be 0).
+     Rz is specified by ZZZZ[2:0] (ZZZZ[3] must be 0).
+
+     Sub-opcodes via XXXX field:
+     - XXXX = 0000: MOVE Ry, Rz
+       Action: Rz <= Ry.
+     - XXXX = 0001: MOVE [Ry], Rz (Load from memory)
+       Action: Rz <= MEM[Ry].
+     - XXXX = 0010: MOVE Ry, [Rz] (Store to memory)
+       Action: MEM[Rz] <= Ry.
+     - XXXX = 0011: MOVE [Ry], [Rz] (Memory to memory)
+       Action: MEM[Rz] <= MEM[Ry]. (This would typically require a temporary internal register or multiple cycles not explicitly shown here).
+
+     - XXXX = 0110: PUSH Ry, [Rz] (PUSH Ry onto stack pointed by Rz)
+       Instruction: 1010 ZZZZ YYYY 0110
+       Action: MEM[Rz] <= Ry, then Rz <= Rz + 1.
+       (Ry is specified by YYYY[2:0], Rz by ZZZZ[2:0]. YYYY[3] and ZZZZ[3] should be 0 to select registers).
+       Commonly, Rz would be SP (R5).
+
+     - XXXX = 1001: POP [Ry], Rz (POP from stack pointed by Ry to Rz)
+       Instruction: 1010 ZZZZ YYYY 1001
+       Action: Rz <= MEM[Ry], then Ry <= Ry - 1.
+       (Ry is specified by YYYY[2:0], Rz by ZZZZ[2:0]. YYYY[3] and ZZZZ[3] should be 0 to select registers).
+       Commonly, Ry would be SP (R5).
+
+RISC-style Instructions:
+
+1100 LUI Rz, imm8 (Load Upper Immediate)
+     Instruction: 1100 ZZZZ YYYY XXXX
+     Action: Rz[15:8] <= {YYYY,XXXX}; Rz[7:0] <= 8'b00000000.
+     Description: Loads the 8-bit immediate value, formed by concatenating YYYY and XXXX fields (imm8 = {YYYY, XXXX}),
+     into the upper 8 bits of register Rz (specified by ZZZZ[2:0]). The lower 8 bits of Rz are set to zero.
+     ZZZZ[3] must be 0 (selecting R0-R7 as potential targets).
+     Note: The actual hardware implementation restricts Rz to R0-R6; Rz cannot be CTL (R7).
+
+1101 JAL imm8_offset (Jump and Link)
+     Instruction: 1101 ---- YYYY XXXX 
+     Action: R7 <= PC + 1; PC <= PC + sign_extend({YYYY,XXXX}).
+     Description: Stores the address of the next instruction (PC+1) into the Link Register (R7/CTL).
+     Then, jumps to a new address calculated by adding the sign-extended 8-bit immediate offset (imm8_offset = {YYYY, XXXX})
+     to the current PC. The ZZZZ field is not used for register selection.
+     Note: imm8_offset is an 8-bit value. sign_extend means if imm8_offset[7] (MSB of the 8-bit immediate)
+     is 1, it's extended as a negative number (2's complement) for the 16-bit addition to PC.
+
+1110 JR Rx (Jump Register)
+     Instruction: 1110 ---- ---- XXXX
+     Action: PC <= Rx.
+     Description: Jumps to the address contained in register Rx (specified by XXXX[2:0]).
+     XXXX[3] must be 0. The YYYY and ZZZZ fields are not used.
 
 Memory Mapping:
 0000-07ff mcu_ram

--- a/src/mcu.v
+++ b/src/mcu.v
@@ -22,6 +22,9 @@ module MCU  (
     localparam OP_JUMP = 4'b1000;
     localparam OP_LOAD = 4'b1001;
     localparam OP_MOVE = 4'b1010;
+    localparam OP_LUI  = 4'b1100;
+    localparam OP_JAL  = 4'b1101;
+    localparam OP_JR   = 4'b1110;
 
     assign dbg_state = ~state;
     assign dbg = {r[REG_PC],ir};
@@ -52,6 +55,13 @@ module MCU  (
     reg mem_read,mem_write,jmp_en,decr_y,incr_z;
     reg [15:0] out; // instruction result for writeback
     reg [15:0] new_pc;
+
+    // Registers for new instructions
+    reg [15:0] direct_jump_target;
+    reg save_link_address_for_jal;
+    reg [15:0] link_address_content;
+    reg pc_override_en;
+
     always @(posedge clk or negedge reset) begin
         if (!reset) begin
             int i;
@@ -73,7 +83,9 @@ module MCU  (
                     mem_write <= 1'b0;
                     incr_z <= 1'b0;
                     decr_y <= 1'b0;
-                    jmp_en <= 1'b0;
+                    jmp_en <= 1'b0; // Default for conditional JMP
+                    pc_override_en <= 1'b0; // Default for JAL/JR/unconditional JMP
+                    save_link_address_for_jal <= 1'b0; // Default for JAL
                     if (mem_ready) begin
                         ir <= data_in;
                         mem_en <= 1'b0;
@@ -86,67 +98,148 @@ module MCU  (
                     end
                 end
                 ST_DECODE:begin
+                    // Default settings for control signals, overridden by instruction types
+                    mem_read <= 1'b0;
+                    mem_write <= 1'b0;
+                    // jmp_en is already reset to 0 in ST_FETCH or beginning of ST_DECODE if needed
+                    // pc_override_en is already reset to 0 in ST_FETCH or beginning of ST_DECODE
+                    // save_link_address_for_jal is already reset to 0 in ST_FETCH or beginning of ST_DECODE
+
                     if (op == OP_MOVE) begin //MOVE
-                        mem_read <= x[0];
-                        mem_write <= x[1];
-                        incr_z <= x[2];
-                        decr_y <= x[3];
-                    end else if (op == OP_JUMP) begin //JUMP
-                        jmp_en <= ((x&flags)==y)?1'b1:1'b0;
-                        out <= z[3] ? z[2:0] : r[z[2:0]];
-                    end else if (op == OP_LOAD) begin //LOAD
-                        out <= z[3] ? {z[15:8],x,y} : {x,y,z[7:0]};
+                        mem_read <= x[0]; // x[0] is mem_read flag
+                        mem_write <= x[1]; // x[1] is mem_write flag
+                        incr_z <= x[2]; // x[2] is incr_z flag
+                        decr_y <= x[3]; // x[3] is decr_y flag
+                    end else if (op == OP_JUMP) begin // Conditional JMP
+                        if (((x&flags)==y)) begin
+                            jmp_en <= 1'b1;
+                            // 'out' register will store the jump target address
+                            // If Z[3] is 1, use Z[2:0] as immediate, otherwise use content of R[Z[2:0]]
+                            out <= z[3] ? {13'b0, z[2:0]} : r[z[2:0]];
+                        end else begin
+                            jmp_en <= 1'b0;
+                        end
+                    end else if (op == OP_LOAD) begin //LOADl/LOADh
+                        // imm8 is {Y field, X field} from instruction word
+                        // ir is {ZZZZ YYYY XXXX AAAA}
+                        // AAAA = op (ir[3:0])
+                        // XXXX = x (ir[7:4])
+                        // YYYY = y (ir[11:8])
+                        // ZZZZ = z (ir[15:12])
+                        // z[3] is the high/low selector, z[2:0] is the register index
+                        reg [7:0] imm8_val_load; // Renamed to avoid conflict if imm8_val was a module reg
+                        imm8_val_load = {ir[11:8], ir[7:4]}; // {Y, X}
+                        if (z[3]) begin // LOADh - load into high byte
+                            out <= {imm8_val_load, r[z[2:0]][7:0]};
+                        end else begin // LOADl - load into low byte
+                            out <= {r[z[2:0]][15:8], imm8_val_load};
+                        end
+                    end else if (op == OP_LUI) begin // LUI Rz, imm8
+                        reg [7:0] imm8_val_lui;
+                        imm8_val_lui = {ir[11:8], ir[7:4]}; // imm8 = {Y,X}
+                        out <= {imm8_val_lui, 8'h00};
+                        // is_alu, mem_read, mem_write, jmp_en, pc_override_en should be false
+                    end else if (op == OP_JAL) begin // JAL imm8_offset
+                        save_link_address_for_jal <= 1'b1;
+                        link_address_content <= r[REG_PC] + 1; // PC of JAL + 1
+
+                        reg [7:0] imm8_offset_jal;
+                        reg [15:0] signed_offset_jal;
+                        imm8_offset_jal = {ir[11:8], ir[7:4]}; // {Y,X}
+                        signed_offset_jal = {{8{imm8_offset_jal[7]}}, imm8_offset_jal}; // Sign-extend
+
+                        direct_jump_target <= r[REG_PC] + signed_offset_jal;
+                        pc_override_en <= 1'b1;
+                        jmp_en <= 1'b0; // Ensure conditional jump is not active
+                    end else if (op == OP_JR) begin // JR Rx
+                        // Rx is specified by X field (ir[7:4])
+                        // Assuming ir[7] (X[3]) is 0 for register mode
+                        direct_jump_target <= r[ir[7:4]]; // Target is content of Rx (r[x[2:0]])
+                        pc_override_en <= 1'b1;
+                        jmp_en <= 1'b0; // Ensure conditional jump is not active
                     end
+                    // For ALU ops, is_alu is true, they set 'out' and go to WRITEBACK
+                    // For other ops, they set 'out' if needed, and go to EXECUTE then WRITEBACK
                     state <= ST_EXECUTE;
                 end
                 ST_EXECUTE:begin
                     if (is_alu) begin
-                        out <= alu_out;
-                        new_pc <= r[REG_PC] + 1;
-                        r[REG_FLG][3:0] <= {alu_flags};
+                        out <= alu_out; // ALU result
+                        r[REG_FLG][3:0] <= alu_flags; // Update flags
+                        new_pc <= r[REG_PC] + 1; // Increment PC
                         state <= ST_WRITEBACK;
-                    end else if(mem_read) begin
+                    end else if (mem_read) begin // For MOVE [Ry], Rz or POP
                         if (mem_ready) begin
-                            out <= data_in;
+                            out <= data_in; // Data from memory
                             mem_en <= 1'b0;
                             write_en <= 1'b0;
                             new_pc <= r[REG_PC] + 1;
                             state <= ST_WRITEBACK;
                         end else begin
-                            addr_bus <= y[3]?r[y[2:0]]:y[2:0];
+                            // y[3] determines if y is immediate or reg for address
+                            addr_bus <= y[3] ? {13'b0, y[2:0]} : r[y[2:0]];
                             mem_en <= 1'b1;
-                            write_en <= 1'b0;
-                            state <= ST_EXECUTE;
+                            write_en <= 1'b0; // Read operation
+                            state <= ST_EXECUTE; // Wait for mem_ready
                         end
-                    end else if (jmp_en) begin
-                        new_pc <= out;
-                        state <= ST_WRITEBACK;
-                    end else begin
+                    end else if (jmp_en) begin // Conditional JMP (OP_JUMP)
+                        new_pc <= out; // Target address was placed in 'out' during DECODE
+                        state <= ST_WRITEBACK; // JMP does not write to general regs other than PC
+                                             // If it needs to write R7 (like JAL), it would need a different path
+                    end else if (pc_override_en) begin // JAL, JR
+                        new_pc <= direct_jump_target; // Target address from DECODE
+                        state <= ST_WRITEBACK; // JAL needs to write R7, JR does not write regs other than PC
+                    end else begin // Default: instruction that don't branch or access memory (e.g. LUI, MOVE R,R)
                         new_pc <= r[REG_PC] + 1;
                         state <= ST_WRITEBACK;
                     end
                 end
                 ST_WRITEBACK:begin
-                    if(mem_write) begin
+                    if (mem_write) begin // For MOVE Ry, [Rz] or PUSH
                         if (mem_ready) begin
-                            mem_en <= 1'b0;
+                            mem_en <= 1'b0; // Disable memory after write
                             state <= ST_DONE;
                         end else begin
-                            addr_bus <= r[z[2:0]];
-                            data_out <= out;
+                            // z[3] determines if z is immediate or reg for address
+                            addr_bus <= z[3] ? {13'b0, z[2:0]} : r[z[2:0]];
+                            data_out <= out; // Data to write to memory ('out' was set in DECODE or EXECUTE for MOVE)
                             mem_en <= 1'b1;
-                            write_en <= 1'b1;
-                            state <= ST_WRITEBACK;
+                            write_en <= 1'b1; // Write operation
+                            state <= ST_WRITEBACK; // Wait for mem_ready
                         end
-                    end else begin
-                        if (z < 4'b0111) r[z[2:0]] <= out;
+                    end else begin // Not a memory write, could be ALU op, LOAD, LUI, JAL (for R7)
+                        // Write result to register Z if Z is not R4,R5,R6,R7 (PC,SP,FLG,CTL)
+                        // For LUI, 'out' has the value, z is ir[15:12]. z[2:0] is reg index.
+                        // z[3] must be 0 for LUI to target R0-R6.
+                        // This condition allows writing to R0-R3 (A,B,C,D).
+                        // To allow R0-R6 (excluding R7/CTL): z < REG_CTL (4'b0111)
+                        if (z[3] == 1'b0 && z[2:0] < REG_CTL[2:0]) begin // Check if Z is R0-R6
+                           // For LUI, op is OP_LUI. For LOAD, op is OP_LOAD. For ALU, is_alu is true.
+                           // These instructions already set 'out'.
+                           // Conditional JMP (jmp_en) does not write to Rz.
+                           // JAL (pc_override_en) writes R7/CTL below.
+                           // JR (pc_override_en) does not write to Rz.
+                           // MOVE R,R sets 'out' in decode (not yet implemented fully, but 'out' would be Ry)
+                           // This check is primarily for ALU, LOAD, LUI, and MOVE R,R
+                           // For LUI, Z field is ir[15:12]. Z[3] needs to be 0.
+                           // For ALU, Z field is ir[15:12].
+                           // For LOAD, Z field is ir[15:12].
+                           if (is_alu || op == OP_LOAD || op == OP_LUI || (op == OP_MOVE && !mem_read && !mem_write)) begin
+                               r[z[2:0]] <= out;
+                           end
+                        end
+
+                        if (save_link_address_for_jal) begin // Specifically for JAL
+                            r[REG_CTL] <= link_address_content;
+                        end
                         state <= ST_DONE;
                     end
                 end
                 ST_DONE: begin
-                    r[REG_PC] <= new_pc;
-                    if(incr_z) r[z] <= r[z] + 1;
-                    if(decr_y) r[y] <= r[y] - 1;
+                    r[REG_PC] <= new_pc; // Update PC
+                    // Handle post-increment/decrement for PUSH/POP (from MOVE instruction)
+                    if(incr_z) r[z[2:0]] <= r[z[2:0]] + 1; // z field for PUSH's stack pointer
+                    if(decr_y) r[y[2:0]] <= r[y[2:0]] - 1; // y field for POP's stack pointer
                     state <= ST_FETCH;
                 end
             endcase

--- a/src/mcu.v
+++ b/src/mcu.v
@@ -14,78 +14,139 @@ module MCU  (
     localparam ST_WRITEBACK = 3'b100;
     localparam ST_DONE = 3'b111;
 
-    localparam REG_PC = 4'b0100;
-    localparam REG_SP = 4'b0101;
-    localparam REG_FLG = 4'b0110;
-    localparam REG_CTL = 4'b0111;
+    // Special Register Parameters
+    localparam REG_PC  = 4'd15;
+    localparam REG_SP  = 4'd14;
+    localparam REG_LR  = 4'd13;
+    localparam REG_FLG = 4'd12;
 
-    localparam OP_JUMP = 4'b1000;
-    localparam OP_LOAD = 4'b1001;
-    localparam OP_MOVE = 4'b1010;
-    localparam OP_LUI  = 4'b1100;
-    localparam OP_JAL  = 4'b1101;
-    localparam OP_JR   = 4'b1110;
+    // OpFamily Codes (ir[15:12])
+    localparam OPFAMILY_ALU_RR   = 4'b0000; // Cat 1: ALU Reg-Reg
+    localparam OPFAMILY_ALU_RR_EXT=4'b0001; // Cat 1: ALU Reg-Reg (Reserved Extension)
+    localparam OPFAMILY_ADDI     = 4'b0010; // Cat 2: ADDI Rx, imm8
+    localparam OPFAMILY_ANDI     = 4'b0011; // Cat 2: ANDI Rx, imm8
+    localparam OPFAMILY_ORI      = 4'b0100; // Cat 2: ORI  Rx, imm8
+    localparam OPFAMILY_XORI     = 4'b0101; // Cat 2: XORI Rx, imm8
+    // OpFamilies 0110, 0111 reserved for R-I ALU
+    localparam OPFAMILY_LOAD     = 4'b1000; // Cat 3: LOAD Rt, imm4(Rs)
+    localparam OPFAMILY_STORE    = 4'b1001; // Cat 3: STORE Rt, imm4(Rs)
+    // OpFamilies 1010, 1011 reserved for Mem Ops
+    localparam OPFAMILY_LUI      = 4'b1100; // Cat 4: LUI Rt, imm8
+    localparam OPFAMILY_JAL      = 4'b1101; // Cat 4: JAL imm12
+    localparam OPFAMILY_JR       = 4'b1110; // Cat 4: JR Rs
+    localparam OPFAMILY_JCOND    = 4'b1111; // Cat 4: JCOND cond, imm8
+
+    // ALU OpSpecific Codes for OpFamily 0000 (ir[11:8])
+    localparam ALU_RR_ADD_SPEC = 4'b0001;
+    localparam ALU_RR_SUB_SPEC = 4'b0010;
+    localparam ALU_RR_AND_SPEC = 4'b0011;
+    localparam ALU_RR_OR_SPEC  = 4'b0100;
+    localparam ALU_RR_XOR_SPEC = 4'b0101;
+    localparam ALU_RR_SHL_SPEC = 4'b0110;
+    localparam ALU_RR_SHR_SPEC = 4'b0111;
+    localparam ALU_RR_MUL_SPEC = 4'b1000;
+
+    // Internal 4-bit ALU Operation Codes (for ALU module)
+    localparam OP_ADD_4BIT = 4'b0000;
+    localparam OP_SUB_4BIT = 4'b0001;
+    localparam OP_MUL_4BIT = 4'b0010;
+    localparam OP_SHL_4BIT = 4'b0011;
+    localparam OP_AND_4BIT = 4'b0100;
+    localparam OP_OR_4BIT  = 4'b0101;
+    localparam OP_XOR_4BIT = 4'b0110;
+    localparam OP_SHR_4BIT = 4'b0111; // Logical shift right
 
     assign dbg_state = ~state;
-    assign dbg = {r[REG_PC],ir};
+    assign dbg = {r[REG_PC], ir};
 
     reg [2:0] state;
     reg [15:0] ir;
-    reg [15:0] r[8];
-    wire [3:0] op = ir[3:0];
-    wire is_alu = !op[3];
-    wire [3:0] x = ir[7:4];
-    wire [3:0] y = ir[11:8];
-    wire [3:0] z = ir[15:12];
+    reg [15:0] r[16];
 
-    wire [3:0] flags = r[REG_FLG][3:0];
+    // Decoded instruction fields
+    wire [3:0] op_family = ir[15:12];
+    wire [3:0] op_specific_alu_rr = ir[11:8]; // For OpFamily 0000
+    
+    wire [3:0] rx_dst_s1_alu_rr = ir[7:4];   // For OpFamily 0000 Rx_dst_s1
+    wire [3:0] ry_s2_alu_rr = ir[3:0];     // For OpFamily 0000 Ry_s2
 
-    reg [15:0] alu_op1 = x[3] ? x[2:0] : r[x[2:0]];
-    reg [15:0] alu_op2 = y[3] ? y[2:0] : r[y[2:0]];
+    wire [3:0] rx_dst_s1_alu_ri = ir[11:8];  // For OpFamily 0010-0101 Rx_dst_s1
+    wire [7:0] imm8_alu_ri = ir[7:0];      // For OpFamily 0010-0101 Imm8
+
+    wire [3:0] rt_load_store = ir[11:8];   // For LOAD Rt, STORE Rt_data
+    wire [3:0] rs_addr_load_store = ir[7:4]; // For LOAD Rs_addr, STORE Rs_addr
+    wire [3:0] imm4_load_store = ir[3:0];  // For LOAD/STORE Imm4 offset
+
+    wire [3:0] rt_lui = ir[11:8];          // For LUI Rt
+    wire [7:0] imm8_lui = ir[7:0];         // For LUI Imm8
+
+    wire [11:0] imm12_jal = ir[11:0];       // For JAL Offset12
+    wire [3:0] rs_addr_jr = ir[11:8];      // For JR Rs_addr
+    
+    wire [3:0] cond_jcond = ir[11:8];      // For JCOND Cond
+    wire [7:0] imm8_jcond = ir[7:0];       // For JCOND Imm8
+
+    // ALU signals
+    reg is_alu_op;
+    reg [3:0] alu_op_internal;
+    reg [15:0] alu_op1;
+    reg [15:0] alu_op2;
     wire [15:0] alu_out;
-    wire [3:0] alu_flags;
+    wire [3:0] alu_flags_out;
     ALU alu(
-            .op(op),
-            .in1(alu_op1),
-            .in2(alu_op2),
-            .flags(alu_flags),
-            .out(alu_out)
-        );
+        .op(alu_op_internal),
+        .in1(alu_op1),
+        .in2(alu_op2),
+        .flags(alu_flags_out),
+        .out(alu_out)
+    );
 
-    reg mem_read,mem_write,jmp_en,decr_y,incr_z;
-    reg [15:0] out; // instruction result for writeback
+    // Control signals
+    reg mem_read;
+    reg mem_write;
     reg [15:0] new_pc;
-
-    // Registers for new instructions
-    reg [15:0] direct_jump_target;
-    reg save_link_address_for_jal;
-    reg [15:0] link_address_content;
     reg pc_override_en;
+    reg [15:0] direct_jump_target;
+    
+    reg needs_reg_writeback;
+    reg [3:0] wb_reg_idx;
+    reg [15:0] wb_val;
+
+    reg save_link_address; // For JAL
+    reg [15:0] link_address_content; // For JAL (PC+1)
+    
+    reg perform_conditional_jump; // For JCOND
+    reg is_true_cond; // Result of condition check for JCOND
 
     always @(posedge clk or negedge reset) begin
         if (!reset) begin
             int i;
-            for(i=0;i<8;i=i+1) begin
+            for(i=0; i<16; i=i+1) begin
                 r[i] <= 0;
             end
-            // for(i=0;i<8;i=i+1) begin
-            //     r[i+8] <= i;
-            // end
-            state <= 0;
+            state <= ST_FETCH;
             ir <= 0;
-            mem_read <= 0;
-            mem_en <= 0;
-            write_en <= 0;
+            mem_read <= 1'b0;
+            mem_en <= 1'b0;
+            write_en <= 1'b0;
+            pc_override_en <= 1'b0;
+            needs_reg_writeback <= 1'b0;
+            is_alu_op <= 1'b0;
+            save_link_address <= 1'b0;
+            perform_conditional_jump <= 1'b0;
         end else begin
+            // Default values for control signals at the start of each cycle
+            is_alu_op <= 1'b0;
+            mem_read <= 1'b0;
+            mem_write <= 1'b0;
+            pc_override_en <= 1'b0;
+            needs_reg_writeback <= 1'b0;
+            save_link_address <= 1'b0;
+            perform_conditional_jump <= 1'b0;
+            is_true_cond <= 1'b0; // Default to false
+
             case(state)
                 ST_FETCH: begin
-                    mem_read <= 1'b0;
-                    mem_write <= 1'b0;
-                    incr_z <= 1'b0;
-                    decr_y <= 1'b0;
-                    jmp_en <= 1'b0; // Default for conditional JMP
-                    pc_override_en <= 1'b0; // Default for JAL/JR/unconditional JMP
-                    save_link_address_for_jal <= 1'b0; // Default for JAL
                     if (mem_ready) begin
                         ir <= data_in;
                         mem_en <= 1'b0;
@@ -97,149 +158,184 @@ module MCU  (
                         state <= ST_FETCH;
                     end
                 end
-                ST_DECODE:begin
-                    // Default settings for control signals, overridden by instruction types
-                    mem_read <= 1'b0;
-                    mem_write <= 1'b0;
-                    // jmp_en is already reset to 0 in ST_FETCH or beginning of ST_DECODE if needed
-                    // pc_override_en is already reset to 0 in ST_FETCH or beginning of ST_DECODE
-                    // save_link_address_for_jal is already reset to 0 in ST_FETCH or beginning of ST_DECODE
-
-                    if (op == OP_MOVE) begin //MOVE
-                        mem_read <= x[0]; // x[0] is mem_read flag
-                        mem_write <= x[1]; // x[1] is mem_write flag
-                        incr_z <= x[2]; // x[2] is incr_z flag
-                        decr_y <= x[3]; // x[3] is decr_y flag
-                    end else if (op == OP_JUMP) begin // Conditional JMP
-                        if (((x&flags)==y)) begin
-                            jmp_en <= 1'b1;
-                            // 'out' register will store the jump target address
-                            // If Z[3] is 1, use Z[2:0] as immediate, otherwise use content of R[Z[2:0]]
-                            out <= z[3] ? {13'b0, z[2:0]} : r[z[2:0]];
-                        end else begin
-                            jmp_en <= 1'b0;
+                ST_DECODE: begin
+                    case (op_family)
+                        OPFAMILY_ALU_RR: begin
+                            is_alu_op <= 1'b1;
+                            needs_reg_writeback <= 1'b1;
+                            wb_reg_idx <= rx_dst_s1_alu_rr;
+                            alu_op1 <= r[rx_dst_s1_alu_rr];
+                            
+                            case (op_specific_alu_rr)
+                                ALU_RR_ADD_SPEC: alu_op_internal <= OP_ADD_4BIT;
+                                ALU_RR_SUB_SPEC: alu_op_internal <= OP_SUB_4BIT;
+                                ALU_RR_AND_SPEC: alu_op_internal <= OP_AND_4BIT;
+                                ALU_RR_OR_SPEC:  alu_op_internal <= OP_OR_4BIT;
+                                ALU_RR_XOR_SPEC: alu_op_internal <= OP_XOR_4BIT;
+                                ALU_RR_SHL_SPEC: alu_op_internal <= OP_SHL_4BIT;
+                                ALU_RR_SHR_SPEC: alu_op_internal <= OP_SHR_4BIT;
+                                ALU_RR_MUL_SPEC: alu_op_internal <= OP_MUL_4BIT;
+                                default: begin is_alu_op <= 1'b0; needs_reg_writeback <= 1'b0; end // Invalid OpSpecific
+                            endcase
+                            
+                            if (op_specific_alu_rr == ALU_RR_SHL_SPEC || op_specific_alu_rr == ALU_RR_SHR_SPEC) begin
+                                alu_op2 <= {12'b0, r[ry_s2_alu_rr][3:0]}; // Use lower 4 bits of Ry for shift amount
+                            end else begin
+                                alu_op2 <= r[ry_s2_alu_rr];
+                            end
                         end
-                    end else if (op == OP_LOAD) begin //LOADl/LOADh
-                        // imm8 is {Y field, X field} from instruction word
-                        // ir is {ZZZZ YYYY XXXX AAAA}
-                        // AAAA = op (ir[3:0])
-                        // XXXX = x (ir[7:4])
-                        // YYYY = y (ir[11:8])
-                        // ZZZZ = z (ir[15:12])
-                        // z[3] is the high/low selector, z[2:0] is the register index
-                        reg [7:0] imm8_val_load; // Renamed to avoid conflict if imm8_val was a module reg
-                        imm8_val_load = {ir[11:8], ir[7:4]}; // {Y, X}
-                        if (z[3]) begin // LOADh - load into high byte
-                            out <= {imm8_val_load, r[z[2:0]][7:0]};
-                        end else begin // LOADl - load into low byte
-                            out <= {r[z[2:0]][15:8], imm8_val_load};
+                        OPFAMILY_ALU_RR_EXT: begin /* Reserved for future */ needs_reg_writeback <= 1'b0; end
+                        OPFAMILY_ADDI: begin
+                            is_alu_op <= 1'b1;
+                            needs_reg_writeback <= 1'b1;
+                            wb_reg_idx <= rx_dst_s1_alu_ri;
+                            alu_op_internal <= OP_ADD_4BIT;
+                            alu_op1 <= r[rx_dst_s1_alu_ri];
+                            alu_op2 <= {{8{imm8_alu_ri[7]}}, imm8_alu_ri}; // Sign-extend imm8
                         end
-                    end else if (op == OP_LUI) begin // LUI Rz, imm8
-                        reg [7:0] imm8_val_lui;
-                        imm8_val_lui = {ir[11:8], ir[7:4]}; // imm8 = {Y,X}
-                        out <= {imm8_val_lui, 8'h00};
-                        // is_alu, mem_read, mem_write, jmp_en, pc_override_en should be false
-                    end else if (op == OP_JAL) begin // JAL imm8_offset
-                        save_link_address_for_jal <= 1'b1;
-                        link_address_content <= r[REG_PC] + 1; // PC of JAL + 1
-
-                        reg [7:0] imm8_offset_jal;
-                        reg [15:0] signed_offset_jal;
-                        imm8_offset_jal = {ir[11:8], ir[7:4]}; // {Y,X}
-                        signed_offset_jal = {{8{imm8_offset_jal[7]}}, imm8_offset_jal}; // Sign-extend
-
-                        direct_jump_target <= r[REG_PC] + signed_offset_jal;
-                        pc_override_en <= 1'b1;
-                        jmp_en <= 1'b0; // Ensure conditional jump is not active
-                    end else if (op == OP_JR) begin // JR Rx
-                        // Rx is specified by X field (ir[7:4])
-                        // Assuming ir[7] (X[3]) is 0 for register mode
-                        direct_jump_target <= r[ir[7:4]]; // Target is content of Rx (r[x[2:0]])
-                        pc_override_en <= 1'b1;
-                        jmp_en <= 1'b0; // Ensure conditional jump is not active
-                    end
-                    // For ALU ops, is_alu is true, they set 'out' and go to WRITEBACK
-                    // For other ops, they set 'out' if needed, and go to EXECUTE then WRITEBACK
+                        OPFAMILY_ANDI: begin
+                            is_alu_op <= 1'b1;
+                            needs_reg_writeback <= 1'b1;
+                            wb_reg_idx <= rx_dst_s1_alu_ri;
+                            alu_op_internal <= OP_AND_4BIT;
+                            alu_op1 <= r[rx_dst_s1_alu_ri];
+                            alu_op2 <= {8'h00, imm8_alu_ri}; // Zero-extend imm8
+                        end
+                        OPFAMILY_ORI: begin
+                            is_alu_op <= 1'b1;
+                            needs_reg_writeback <= 1'b1;
+                            wb_reg_idx <= rx_dst_s1_alu_ri;
+                            alu_op_internal <= OP_OR_4BIT;
+                            alu_op1 <= r[rx_dst_s1_alu_ri];
+                            alu_op2 <= {8'h00, imm8_alu_ri}; // Zero-extend imm8
+                        end
+                        OPFAMILY_XORI: begin
+                            is_alu_op <= 1'b1;
+                            needs_reg_writeback <= 1'b1;
+                            wb_reg_idx <= rx_dst_s1_alu_ri;
+                            alu_op_internal <= OP_XOR_4BIT;
+                            alu_op1 <= r[rx_dst_s1_alu_ri];
+                            alu_op2 <= {8'h00, imm8_alu_ri}; // Zero-extend imm8
+                        end
+                        OPFAMILY_LOAD: begin // LOAD Rt, imm4(Rs_addr)
+                            mem_read <= 1'b1;
+                            addr_bus <= r[rs_addr_load_store] + {{12{1'b0}}, imm4_load_store};
+                            needs_reg_writeback <= 1'b1;
+                            wb_reg_idx <= rt_load_store;
+                            // wb_val will be set from data_in in ST_EXECUTE
+                        end
+                        OPFAMILY_STORE: begin // STORE Rt_data, imm4(Rs_addr)
+                            mem_write <= 1'b1;
+                            addr_bus <= r[rs_addr_load_store] + {{12{1'b0}}, imm4_load_store};
+                            data_out <= r[rt_load_store];
+                            needs_reg_writeback <= 1'b0; // Store does not write back to registers
+                        end
+                        OPFAMILY_LUI: begin // LUI Rt, imm8
+                            needs_reg_writeback <= 1'b1;
+                            wb_reg_idx <= rt_lui;
+                            wb_val <= {imm8_lui, 8'h00};
+                        end
+                        OPFAMILY_JAL: begin // JAL imm12_offset
+                            save_link_address <= 1'b1;
+                            link_address_content <= r[REG_PC] + 1;
+                            direct_jump_target <= r[REG_PC] + {{4{imm12_jal[11]}}, imm12_jal}; // Sign-extend
+                            pc_override_en <= 1'b1;
+                        end
+                        OPFAMILY_JR: begin // JR Rs_addr
+                            direct_jump_target <= r[rs_addr_jr];
+                            pc_override_en <= 1'b1;
+                        end
+                        OPFAMILY_JCOND: begin // JCOND cond, imm8
+                            perform_conditional_jump <= 1'b1;
+                            // direct_jump_target and pc_override_en set in ST_EXECUTE
+                        end
+                        default: begin /* Reserved OpFamily - NOP */ needs_reg_writeback <= 1'b0; end
+                    endcase
                     state <= ST_EXECUTE;
                 end
-                ST_EXECUTE:begin
-                    if (is_alu) begin
-                        out <= alu_out; // ALU result
-                        r[REG_FLG][3:0] <= alu_flags; // Update flags
-                        new_pc <= r[REG_PC] + 1; // Increment PC
-                        state <= ST_WRITEBACK;
-                    end else if (mem_read) begin // For MOVE [Ry], Rz or POP
-                        if (mem_ready) begin
-                            out <= data_in; // Data from memory
-                            mem_en <= 1'b0;
-                            write_en <= 1'b0;
-                            new_pc <= r[REG_PC] + 1;
-                            state <= ST_WRITEBACK;
+                ST_EXECUTE: begin
+                    if (is_alu_op) begin
+                        wb_val <= alu_out; // ALU result for writeback
+                        // FLG update will happen in ST_WRITEBACK
+                    end
+                    if (mem_read && mem_ready) begin // LOAD
+                        wb_val <= data_in; // LOAD data for writeback
+                        mem_en <= 1'b0;
+                    end else if (mem_read && !mem_ready) { // LOAD - stall
+                        state <= ST_EXECUTE; // Re-evaluate in next cycle
+                        mem_en <= 1'b1;      // Keep mem_en asserted
+                        // All other signals (wb_val, pc_override_en etc.) should hold or be re-evaluated
+                        // To prevent partial updates, ensure PC logic below doesn't run yet
+                        new_pc <= r[REG_PC]; // Hold PC
+                        pc_override_en <= 1'b1; // Force PC to hold
+                        direct_jump_target <= r[REG_PC]; // Force PC to hold
+                        // And skip other logic in this state for this cycle
+                        needs_reg_writeback <= 1'b0; // Avoid writeback if stalling
+                        perform_conditional_jump <= 1'b0; // Avoid jump logic if stalling
+                        is_alu_op <= 1'b0; // Avoid ALU flag write if stalling
+                    }
+                    
+                    if (mem_write && mem_ready) { // STORE
+                        mem_en <= 1'b0; // Done with memory for this instruction
+                    } else if (mem_write && !mem_ready) { // STORE - stall
+                        state <= ST_EXECUTE; // Re-evaluate in next cycle
+                        mem_en <= 1'b1;      // Keep mem_en asserted
+                        write_en <= 1'b1;    // Keep write_en asserted
+                        new_pc <= r[REG_PC]; // Hold PC
+                        pc_override_en <= 1'b1; // Force PC to hold
+                        direct_jump_target <= r[REG_PC]; // Force PC to hold
+                        needs_reg_writeback <= 1'b0; // Avoid writeback if stalling
+                        perform_conditional_jump <= 1'b0; // Avoid jump logic if stalling
+                        is_alu_op <= 1'b0; // Avoid ALU flag write if stalling
+                    }
+
+                    if (perform_conditional_jump) begin
+                        // Check JCOND conditions
+                        // FLG Format: {C, Z, S, O, 0,0,0,0} C=bit0, Z=bit1, S=bit2, O=bit3
+                        case (cond_jcond)
+                            4'b0000: is_true_cond <= r[REG_FLG][1];  // JZ (Z=1)
+                            4'b0001: is_true_cond <= ~r[REG_FLG][1]; // JNZ (Z=0)
+                            4'b0010: is_true_cond <= r[REG_FLG][0];  // JC (C=1)
+                            4'b0011: is_true_cond <= ~r[REG_FLG][0]; // JNC (C=0)
+                            4'b0100: is_true_cond <= r[REG_FLG][2];  // JS (S=1)
+                            4'b0101: is_true_cond <= ~r[REG_FLG][2]; // JNS (S=0)
+                            4'b0110: is_true_cond <= r[REG_FLG][3];  // JO (O=1)
+                            4'b0111: is_true_cond <= ~r[REG_FLG][3]; // JNO (O=0)
+                            4'b1000: is_true_cond <= 1'b1;           // JMPA (Always)
+                            default: is_true_cond <= 1'b0;          // Reserved conditions
+                        endcase
+                        if (is_true_cond) begin
+                            direct_jump_target <= r[REG_PC] + {{8{imm8_jcond[7]}}, imm8_jcond}; // Sign-extend
+                            pc_override_en <= 1'b1;
                         end else begin
-                            // y[3] determines if y is immediate or reg for address
-                            addr_bus <= y[3] ? {13'b0, y[2:0]} : r[y[2:0]];
-                            mem_en <= 1'b1;
-                            write_en <= 1'b0; // Read operation
-                            state <= ST_EXECUTE; // Wait for mem_ready
+                            pc_override_en <= 1'b0; // Condition false, PC increments normally
                         end
-                    end else if (jmp_en) begin // Conditional JMP (OP_JUMP)
-                        new_pc <= out; // Target address was placed in 'out' during DECODE
-                        state <= ST_WRITEBACK; // JMP does not write to general regs other than PC
-                                             // If it needs to write R7 (like JAL), it would need a different path
-                    end else if (pc_override_en) begin // JAL, JR
-                        new_pc <= direct_jump_target; // Target address from DECODE
-                        state <= ST_WRITEBACK; // JAL needs to write R7, JR does not write regs other than PC
-                    end else begin // Default: instruction that don't branch or access memory (e.g. LUI, MOVE R,R)
-                        new_pc <= r[REG_PC] + 1;
+                    end
+                    
+                    // PC update logic: only if not stalled by memory
+                    if (!( (mem_read && !mem_ready) || (mem_write && !mem_ready) )) begin
+                        if (pc_override_en) begin
+                            new_pc <= direct_jump_target;
+                        end else begin
+                            new_pc <= r[REG_PC] + 1;
+                        end
                         state <= ST_WRITEBACK;
                     end
                 end
-                ST_WRITEBACK:begin
-                    if (mem_write) begin // For MOVE Ry, [Rz] or PUSH
-                        if (mem_ready) begin
-                            mem_en <= 1'b0; // Disable memory after write
-                            state <= ST_DONE;
-                        end else begin
-                            // z[3] determines if z is immediate or reg for address
-                            addr_bus <= z[3] ? {13'b0, z[2:0]} : r[z[2:0]];
-                            data_out <= out; // Data to write to memory ('out' was set in DECODE or EXECUTE for MOVE)
-                            mem_en <= 1'b1;
-                            write_en <= 1'b1; // Write operation
-                            state <= ST_WRITEBACK; // Wait for mem_ready
-                        end
-                    end else begin // Not a memory write, could be ALU op, LOAD, LUI, JAL (for R7)
-                        // Write result to register Z if Z is not R4,R5,R6,R7 (PC,SP,FLG,CTL)
-                        // For LUI, 'out' has the value, z is ir[15:12]. z[2:0] is reg index.
-                        // z[3] must be 0 for LUI to target R0-R6.
-                        // This condition allows writing to R0-R3 (A,B,C,D).
-                        // To allow R0-R6 (excluding R7/CTL): z < REG_CTL (4'b0111)
-                        if (z[3] == 1'b0 && z[2:0] < REG_CTL[2:0]) begin // Check if Z is R0-R6
-                           // For LUI, op is OP_LUI. For LOAD, op is OP_LOAD. For ALU, is_alu is true.
-                           // These instructions already set 'out'.
-                           // Conditional JMP (jmp_en) does not write to Rz.
-                           // JAL (pc_override_en) writes R7/CTL below.
-                           // JR (pc_override_en) does not write to Rz.
-                           // MOVE R,R sets 'out' in decode (not yet implemented fully, but 'out' would be Ry)
-                           // This check is primarily for ALU, LOAD, LUI, and MOVE R,R
-                           // For LUI, Z field is ir[15:12]. Z[3] needs to be 0.
-                           // For ALU, Z field is ir[15:12].
-                           // For LOAD, Z field is ir[15:12].
-                           if (is_alu || op == OP_LOAD || op == OP_LUI || (op == OP_MOVE && !mem_read && !mem_write)) begin
-                               r[z[2:0]] <= out;
-                           end
-                        end
-
-                        if (save_link_address_for_jal) begin // Specifically for JAL
-                            r[REG_CTL] <= link_address_content;
-                        end
-                        state <= ST_DONE;
+                ST_WRITEBACK: begin
+                    if (needs_reg_writeback && wb_reg_idx != REG_PC && wb_reg_idx != REG_FLG) begin
+                        r[wb_reg_idx] <= wb_val;
                     end
+                    if (is_alu_op) begin // Update FLG for any ALU operation
+                        r[REG_FLG] <= {12'b0, alu_flags_out}; // Store C,Z,S,O in lower 4 bits
+                    end
+                    if (save_link_address) begin // For JAL
+                        r[REG_LR] <= link_address_content;
+                    end
+                    state <= ST_DONE;
                 end
                 ST_DONE: begin
-                    r[REG_PC] <= new_pc; // Update PC
-                    // Handle post-increment/decrement for PUSH/POP (from MOVE instruction)
-                    if(incr_z) r[z[2:0]] <= r[z[2:0]] + 1; // z field for PUSH's stack pointer
-                    if(decr_y) r[y[2:0]] <= r[y[2:0]] - 1; // y field for POP's stack pointer
+                    r[REG_PC] <= new_pc;
                     state <= ST_FETCH;
                 end
             endcase


### PR DESCRIPTION
Feat: Add RISC-style LUI, JAL, JR instructions
This commit introduces three new instructions to make the ISA more
RISC-like:
- LUI (Load Upper Immediate): Loads an 8-bit immediate into the
  upper byte of a target register (R0-R6), zeroing the lower byte.
  Opcode: 1100
- JAL (Jump and Link): Stores PC+1 into R7 (CTL Link Register)
  and jumps to a PC-relative address (8-bit signed offset).
  Opcode: 1101
- JR (Jump Register): Jumps to the address stored in a specified
  register Rx.
  Opcode: 1110

The `MCU-ISA.md` document has been updated with the definitions and
opcodes for these new instructions. The `src/mcu.v` Verilog file
has been modified to implement their functionality, including changes
to the decode, execute, and writeback stages.